### PR TITLE
Add new FBPermission structure to handle new v2 fb permissions api

### DIFF
--- a/m3/api/FBResponse.hx
+++ b/m3/api/FBResponse.hx
@@ -17,7 +17,7 @@ typedef AuthResponse = {
 }
 
 class FBPermissionsResponse {
-	public var data: Array<FBPermissions>;
+	public var data: Array<FBPermission>;
 	public var paging: FBPaging;
 }
 
@@ -99,6 +99,11 @@ class AppFriendProfile {
 class FBAppFriendsResponse extends FBResponse {
 	public var data: Array<AppFriendProfile>;
 	@:optional public var paging: FBPaging;
+}
+
+class FBPermission {
+	public var permission: String;
+	public var status: String;
 }
 
 class FBPermissions {


### PR DESCRIPTION
This data structure was designed for v1 FB Permissions API, which is now obsolete. I added a new class "FBPermission" which reflects how FB sends back permission details in the v2 API (https://developers.facebook.com/docs/graph-api/reference/permission/), and made FBPermissionResponse use that instead. I kept the old FBPermissions structure as it is still being used by the bonzo app and is handier than FBPermission. 
